### PR TITLE
bugfix: Do not print wrong directory name when accesing root

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -890,7 +890,7 @@ static void DirChangeCheck(std::string Source)
                 Gprintf("\n");
             }
             Eka=0;
-            Gprintf(" Directory of %s\n", Source.size() ? Source : ".");
+            Gprintf(" Directory of %s\n", Source.size() ? Source : "/");
         }
         CurrentColumn = 0;
         LastDir = Source;


### PR DESCRIPTION
When accessing "/", the program printed
"Directory of ." instead of "Directory of /".

Fix for #2