### PR TITLE
bugfix: cons.cc didn't know std::array (compile error)

### DIFF
--- a/cons.cc
+++ b/cons.cc
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
+#include <array>
 
 using namespace std;
 


### PR DESCRIPTION
In Debian Buster 10.5 using g++ 8.3.0 didn't compile cons.cc while running a simple 'make' in unmodified repository.