### PR TITLE
Improve color handling and DIRR_COLORS

### DIFF
--- a/cons.cc
+++ b/cons.cc
@@ -268,8 +268,10 @@ void SetAttr(int newattr)
 static int Line;
 int Gputch(int x)
 {
-    // When background color = foreground color, print only blanks
-    if(BackgroundOf(TextAttr) == ForegroundOf(TextAttr) && x > ' ') x = ' ';
+    // When characters would be invisible, print only blanks
+    if(BackgroundOf(TextAttr) == ForegroundOf(TextAttr) &&
+       !BoldOf(TextAttr) && !BlinkOf(TextAttr) && x > ' ')
+        x = ' ';
 
     // When printing a newline, always do that with default background color
     if(x=='\n' && BackgroundOf(TextAttr) != 0) GetDescrColor(ColorDescr::TEXT, 1);

--- a/dirrsets.hh
+++ b/dirrsets.hh
@@ -48,6 +48,7 @@ For xterm-256color formats:
      * ? for links whose destinations does not exist
      *
      * Note: Colour 0 disables the character being printed.
+     * (However, space will still be used.)
      *
      **************************************************************/
     "info(/1,*2,@3,=5,|8,?C,&F)"

--- a/dirrsets.hh
+++ b/dirrsets.hh
@@ -120,6 +120,7 @@ For xterm-256color formats:
      * of it. If it has 'i', the file name patterns are case insensitive.
      *
      * There may be multiple byext() definitions.
+     * Use 'byext()' to clear existing definitions.
      *
      * Wildcards recognized:
      *    ?     Matches any byte

--- a/setfun.cc
+++ b/setfun.cc
@@ -121,8 +121,10 @@ public:
             const char* var = getenv("DIRR_COLORS");
             if(var)
             {
-                auto i = find_range("byext");
-                sets.erase(i.first, i.second);
+                if (std::strstr(var, "byext") != NULL) {
+                    auto i = find_range("byext");
+                    sets.erase(i.first, i.second);
+                }
                 Load(var);
             }
             Parse();
@@ -188,6 +190,8 @@ private:
             std::string key = s.substr(pos, key_end-pos);
             if(parens_pos == s.size())
             {
+                if (key != "byext")
+                    sets.erase(key);
                 sets.emplace(std::move(key), std::string{});
                 return;
             }
@@ -201,6 +205,8 @@ private:
             std::size_t value_end = end_parens_pos;
             while(value_end > value_begin && std::isspace(s[value_end-1])) --value_end;
 
+            if (key != "byext")
+                sets.erase(key);
             sets.emplace(std::move(key), s.substr(value_begin, value_end-value_begin));
             pos = end_parens_pos+1;
         }
@@ -213,7 +219,7 @@ private:
         {
             if(s.first == "mode" || s.first == "type" || s.first == "info")
             {
-                // Parse "txt", "mode" and "info".
+                // Parse "type", "mode" and "info".
                 // These strings in DIRR_COLORS have the format: text(sC,...)
                 // Where s is the character key
                 // and   C is the color code.
@@ -266,7 +272,7 @@ private:
             }
             else
             {
-                // Parse "txt", "owner", "group", "nrlink", "date", or "num".
+                // Parse "txt", "owner", "group", "nrlink", "date", "num", "descr", or "size".
                 // These strings in DIRR_COLORS have the format: text(color,...)
                 int m = ColorDescrFromName(s.first);
                 if(m == -1)


### PR DESCRIPTION
1) Default fifo type character color was invisible since 2d93da9078, because its color is high-intensity black (8) and Gputch only checked that foreground != background.
a) Check bold and blink attributes as well as color.
2) `DIRR_COLORS` variable created duplicates in `type()`, `info()`, etc., causing inconsistent results.
a) Replace color settings specified in `DIRR_COLORS` instead of just adding.
3) Setting anything in `DIRR_COLORS` removed default byext coloring, even with no new byext specified.
a) Only delete byext when a byext pattern is included in `DIRR_COLORS` (`byext()` for none).
4) Also modified `GetName` to ignore nonprinted (colored 0) type characters in spacing calculations.