### PR TITLE
Fix some bugs with column width

### DIFF
--- a/cons.hh
+++ b/cons.hh
@@ -179,6 +179,10 @@ std::size_t WidthPrintHelper(std::size_t maxlen, std::string_view buf, bool fill
                 // Also, no single-byte character is double-wide.
                 goto invalid_unicode_char;
             }
+            // If a doublewide character would be too many columns,
+            // end the loop now.
+            if (column == maxlen-1 && is_doublewide(seq))
+                break;
             // But print it byte by byte.
             if(print)
                 for(unsigned n=0; n<length; ++n)

--- a/main.cc
+++ b/main.cc
@@ -457,7 +457,7 @@ static void TellMe(const StatType &Stat, std::string&& Name
         //fprintf(stderr, "ItemLen=%zu, RowLen becomes %zu\n", ItemLen, RowLen+ItemLen);
         RowLen += ItemLen;
         // Make a newline if the _next_ item of the same width would not fit
-        if(!MultiColumn || int(RowLen + ItemLen) >= int(COLS))
+        if(!MultiColumn || (!VerticalColumns && int(RowLen + ItemLen) >= int(COLS)))
         {
             Gputch('\n');
             RowLen = 0;


### PR DESCRIPTION
* In the vertical columns mode, newlines were added based on a repeat of the previous item's width, even though that is not necessarily true.
* If the last character of a filename that fits in the given space is doublewide, it was not cut off correctly.

I've also noticed the following issues, but I'm not sure exactly how to fix them:
* Using columns (-C) without vertical columns mode prefers cutting off filenames to stay in two columns rather than going to one column. (Maybe intended - if so, there is another bug adding newlines when filenames need to be cut off.)
* In vertical columns mode, filenames are not cut off to fit when only one column is possible, instead causing native wrapping by the terminal.